### PR TITLE
fixes #2163

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -113,6 +113,13 @@
 	dispenser = 1
 
 /obj/item/weapon/handcuffs/cyborg/attack(mob/living/carbon/C, mob/user)
+	if(ishuman(C))
+		var/mob/living/carbon/human/target = C
+		var/obj/item/organ/external/l_arm/BPL = target.bodyparts_by_name[BP_L_ARM]
+		var/obj/item/organ/external/r_arm/BPR = target.bodyparts_by_name[BP_R_ARM]
+		if(!BPL.is_usable() || !BPR.is_usable())
+			to_chat(user, "<span class = 'warning'>[target] has to have both of \his hands intact to be restrained.</span>")
+			return
 	if(!C.handcuffed)
 		var/turf/p_loc = user.loc
 		var/turf/p_loc_m = C.loc


### PR DESCRIPTION
Борги больше не могут надевать наручники на безруких. По крайней мере не должны.

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
🆑 LLIIkolnik
 - bugfix: Борги больше не могут надевать наручники на безруких.